### PR TITLE
Fixed Forge's DimensionRegisterPacket being ignored after handshake.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -181,8 +181,17 @@ public class ServerConnector extends PacketHandler
             user.setServerEntityId( login.getEntityId() );
 
             // Set tab list size, this sucks balls, TODO: what shall we do about packet mutability
-            Login modLogin = new Login( login.getEntityId(), login.getGameMode(), (byte) login.getDimension(), login.getDifficulty(),
+            // Forge allows dimension ID's > 127
+            Login modLogin;
+            if ( handshakeHandler != null && handshakeHandler.isServerForge() )
+            {
+                modLogin = new Login( login.getEntityId(), login.getGameMode(), login.getDimension(), login.getDifficulty(),
                     (byte) user.getPendingConnection().getListener().getTabListSize(), login.getLevelType(), login.isReducedDebugInfo() );
+            } else
+            {
+                modLogin = new Login( login.getEntityId(), login.getGameMode(), (byte) login.getDimension(), login.getDifficulty(),
+                        (byte) user.getPendingConnection().getListener().getTabListSize(), login.getLevelType(), login.isReducedDebugInfo() );
+            }
 
             user.unsafe().sendPacket( modLogin );
 
@@ -313,9 +322,10 @@ public class ServerConnector extends PacketHandler
             }
         }
 
-        if ( pluginMessage.getTag().equals( ForgeConstants.FML_HANDSHAKE_TAG ) || pluginMessage.getTag().equals( ForgeConstants.FORGE_REGISTER ) )
+        // We must bypass our handler once handshake is complete in order to send DimensionRegisterPacket's during Login.
+        if ( !handshakeHandler.isHandshakeComplete() && ( pluginMessage.getTag().equals( ForgeConstants.FML_HANDSHAKE_TAG ) || pluginMessage.getTag().equals( ForgeConstants.FORGE_REGISTER ) ) )
         {
-            this.handshakeHandler.handle( pluginMessage );
+            handshakeHandler.handle( pluginMessage );
             if ( user.getForgeClientHandler().checkUserOutdated() )
             {
                 ch.close();

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandler.java
@@ -82,4 +82,14 @@ public class ForgeServerHandler
     {
         serverForge = true;
     }
+
+    /**
+     * Returns whether the handshake is complete.
+     *
+     * @return <code>true</code> if the handshake has been completed.
+     */
+    public boolean isHandshakeComplete()
+    {
+        return this.state == ForgeServerHandshakeState.DONE;
+    }
 }

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandshakeState.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandshakeState.java
@@ -132,6 +132,9 @@ public enum ForgeServerHandshakeState implements IForgeServerPacketHandler<Forge
                 @Override
                 public ForgeServerHandshakeState send(PluginMessage message, UserConnection con)
                 {
+                    // Packets should never make it here but if they ever do, pass everything to client
+                    ForgeLogger.logServer( LogDirection.SENDING, this.name(), message);
+                    con.unsafe().sendPacket(message);
                     return this;
                 }
             }


### PR DESCRIPTION
After a client switched to a plugin-created dimension and restarted client,
the next login would result in a crash. This was caused by Forge's
DimensionRegisterPacket being ignored during the "DONE" phase of our
ForgeServerHandshakeState class. To fix this issue and others like it,
we now pass all packets directly to client after handshake is done.

More information about this issue can be found here

https://github.com/MinecraftPortCentral/Cauldron-Issues/issues/4
- Added Forge login support for dimension ID's > 127.
